### PR TITLE
feat: Upgrade to PHP 8.2+ with modern features and resolved tool conf…

### DIFF
--- a/src/Dialects/ComposerDialect.php
+++ b/src/Dialects/ComposerDialect.php
@@ -113,18 +113,18 @@ final class ComposerDialect implements DialectInterface
         $version = preg_replace('/@(stable|dev|alpha|beta|RC)$/i', '', $version);
 
         // Handle version aliases (e.g., "dev-master as 1.0.x-dev")
-        if (str_contains($version, ' as ')) {
-            [$actual, $alias] = explode(' as ', $version, 2);
+        if (str_contains((string) $version, ' as ')) {
+            [$actual, $alias] = explode(' as ', (string) $version, 2);
             $version = trim($alias);
         }
 
         // Handle dev branches (e.g., "dev-feature-branch")
-        if (str_starts_with($version, 'dev-')) {
+        if (str_starts_with((string) $version, 'dev-')) {
             // Convert to a high version for comparison purposes
             $version = '999999.999999.999999-dev';
         }
 
-        return trim($version);
+        return trim((string) $version);
     }
 
     /**
@@ -143,6 +143,6 @@ final class ComposerDialect implements DialectInterface
         // Handle inline aliases
         $range = preg_replace('/\s+as\s+[^\s,|]+/', '', $range);
 
-        return trim($range);
+        return trim((string) $range);
     }
 }

--- a/src/Dialects/GoModDialect.php
+++ b/src/Dialects/GoModDialect.php
@@ -9,6 +9,7 @@ use Grazulex\SemverSieve\Parsers\RangeParser;
 use Grazulex\SemverSieve\Parsers\VersionParser;
 use Grazulex\SemverSieve\ValueObjects\ParsedRange;
 use Grazulex\SemverSieve\ValueObjects\ParsedVersion;
+use InvalidArgumentException;
 
 /**
  * Go Modules dialect implementation.
@@ -18,7 +19,8 @@ final class GoModDialect implements DialectInterface
     public function __construct(
         private readonly VersionParser $versionParser = new VersionParser(),
         private readonly RangeParser $rangeParser = new RangeParser(new VersionParser()),
-    ) {}
+    ) {
+    }
 
     /**
      * @param array<string, mixed> $options
@@ -27,9 +29,9 @@ final class GoModDialect implements DialectInterface
     {
         // Go modules require 'v' prefix
         if (!str_starts_with($version, 'v')) {
-            throw new \InvalidArgumentException("Go module version must start with 'v': {$version}");
+            throw new InvalidArgumentException("Go module version must start with 'v': {$version}");
         }
-        
+
         return $this->versionParser->parse($version, $options);
     }
 

--- a/src/Dialects/NugetDialect.php
+++ b/src/Dialects/NugetDialect.php
@@ -18,7 +18,8 @@ final class NugetDialect implements DialectInterface
     public function __construct(
         private readonly VersionParser $versionParser = new VersionParser(),
         private readonly RangeParser $rangeParser = new RangeParser(new VersionParser()),
-    ) {}
+    ) {
+    }
 
     /**
      * @param array<string, mixed> $options

--- a/src/Dialects/PypiDialect.php
+++ b/src/Dialects/PypiDialect.php
@@ -18,7 +18,8 @@ final class PypiDialect implements DialectInterface
     public function __construct(
         private readonly VersionParser $versionParser = new VersionParser(),
         private readonly RangeParser $rangeParser = new RangeParser(new VersionParser()),
-    ) {}
+    ) {
+    }
 
     /**
      * @param array<string, mixed> $options

--- a/src/Dialects/RubyGemsDialect.php
+++ b/src/Dialects/RubyGemsDialect.php
@@ -18,7 +18,8 @@ final class RubyGemsDialect implements DialectInterface
     public function __construct(
         private readonly VersionParser $versionParser = new VersionParser(),
         private readonly RangeParser $rangeParser = new RangeParser(new VersionParser()),
-    ) {}
+    ) {
+    }
 
     /**
      * @param array<string, mixed> $options

--- a/src/Evaluators/RangeEvaluator.php
+++ b/src/Evaluators/RangeEvaluator.php
@@ -107,7 +107,7 @@ final class RangeEvaluator
     {
         $satisfying = $this->filterSatisfying($versions, $range);
 
-        if (empty($satisfying)) {
+        if ($satisfying === []) {
             return null;
         }
 
@@ -131,7 +131,7 @@ final class RangeEvaluator
     {
         $satisfying = $this->filterSatisfying($versions, $range);
 
-        if (empty($satisfying)) {
+        if ($satisfying === []) {
             return null;
         }
 

--- a/src/Exceptions/SemverSieveException.php
+++ b/src/Exceptions/SemverSieveException.php
@@ -57,7 +57,7 @@ abstract class SemverSieveException extends Exception
     {
         $message = $this->getMessage();
 
-        if (!empty($this->context)) {
+        if ($this->context !== []) {
             $contextString = $this->formatContext();
             $message .= " Context: {$contextString}";
         }

--- a/src/Parsers/RangeParser.php
+++ b/src/Parsers/RangeParser.php
@@ -282,7 +282,7 @@ final class RangeParser implements ParserInterface
         // Split on spaces and filter empty parts
         $parts = array_filter(array_map('trim', preg_split('/\s+/', $input)));
 
-        if (empty($parts)) {
+        if ($parts === []) {
             throw InvalidRangeException::forRange($input, 'No valid constraints found');
         }
 

--- a/src/Parsers/VersionParser.php
+++ b/src/Parsers/VersionParser.php
@@ -53,13 +53,13 @@ final class VersionParser implements ParserInterface
 
         // Parse prerelease identifiers
         $prerelease = [];
-        if (!empty($matches['prerelease'])) {
+        if (isset($matches['prerelease']) && ($matches['prerelease'] !== '' && $matches['prerelease'] !== '0')) {
             $prerelease = $this->parsePrereleaseIdentifiers($matches['prerelease'], $options);
         }
 
         // Parse build metadata
         $build = [];
-        if (!empty($matches['build'])) {
+        if (isset($matches['build']) && ($matches['build'] !== '' && $matches['build'] !== '0')) {
             $build = $this->parseBuildIdentifiers($matches['build']);
         }
 

--- a/src/Sieve.php
+++ b/src/Sieve.php
@@ -20,21 +20,18 @@ use Grazulex\SemverSieve\ValueObjects\ParsedVersion;
  */
 final class Sieve
 {
-    private readonly VersionComparatorInterface $comparator;
-
     private readonly RangeEvaluator $evaluator;
 
     /**
      * @param DialectInterface $dialect The version dialect to use for parsing
      * @param SieveConfiguration|null $configuration Configuration options
-     * @param VersionComparatorInterface|null $comparator Custom version comparator
+     * @param VersionComparatorInterface $comparator Custom version comparator
      */
     public function __construct(
         private readonly DialectInterface $dialect,
         private readonly ?SieveConfiguration $configuration = null,
-        ?VersionComparatorInterface $comparator = null,
+        private readonly VersionComparatorInterface $comparator = new SemverComparator(),
     ) {
-        $this->comparator = $comparator ?? new SemverComparator();
         $this->evaluator = new RangeEvaluator($this->comparator, $this->configuration);
     }
 
@@ -77,7 +74,7 @@ final class Sieve
         }
 
         return [
-            'matched' => count($matchedRanges) > 0,
+            'matched' => $matchedRanges !== [],
             'matched_ranges' => $matchedRanges,
             'normalized_ranges' => $normalizedRanges,
         ];

--- a/src/ValueObjects/ParsedRange.php
+++ b/src/ValueObjects/ParsedRange.php
@@ -35,7 +35,7 @@ final readonly class ParsedRange
      */
     public function hasConstraints(): bool
     {
-        return count($this->constraints) > 0;
+        return $this->constraints !== [];
     }
 
     /**
@@ -43,7 +43,7 @@ final readonly class ParsedRange
      */
     public function allowsPrereleases(): bool
     {
-        if (empty($this->constraints)) {
+        if ($this->constraints === []) {
             return false;
         }
 
@@ -90,7 +90,7 @@ final readonly class ParsedRange
      */
     public function toNormalizedString(): string
     {
-        if (empty($this->constraints)) {
+        if ($this->constraints === []) {
             return '*';
         }
 

--- a/src/ValueObjects/ParsedVersion.php
+++ b/src/ValueObjects/ParsedVersion.php
@@ -39,7 +39,7 @@ final readonly class ParsedVersion
      */
     public function isPrerelease(): bool
     {
-        return count($this->prerelease) > 0;
+        return $this->prerelease !== [];
     }
 
     /**
@@ -47,7 +47,7 @@ final readonly class ParsedVersion
      */
     public function hasBuildMetadata(): bool
     {
-        return count($this->build) > 0;
+        return $this->build !== [];
     }
 
     /**

--- a/src/ValueObjects/VersionConstraint.php
+++ b/src/ValueObjects/VersionConstraint.php
@@ -38,8 +38,11 @@ final readonly class VersionConstraint
      */
     public function allowsPrereleases(): bool
     {
-        return $this->version->isPrerelease() ||
-               in_array($this->operator, ['>', '>='], true);
+        if ($this->version->isPrerelease()) {
+            return true;
+        }
+
+        return in_array($this->operator, ['>', '>='], true);
     }
 
     /**

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -26,9 +26,7 @@ declare(strict_types=1);
 |
 */
 
-expect()->extend('toBeOne', function () {
-    return $this->toBe(1);
-});
+expect()->extend('toBeOne', fn () => $this->toBe(1));
 
 /*
 |--------------------------------------------------------------------------

--- a/tests/Unit/AllDialectsTest.php
+++ b/tests/Unit/AllDialectsTest.php
@@ -12,8 +12,8 @@ use Grazulex\SemverSieve\Dialects\PypiDialect;
 use Grazulex\SemverSieve\Dialects\RubyGemsDialect;
 use Grazulex\SemverSieve\Sieve;
 
-describe('All Dialects Implementation', function () {
-    it('can instantiate all 8 dialects', function () {
+describe('All Dialects Implementation', function (): void {
+    it('can instantiate all 8 dialects', function (): void {
         $dialects = [
             'generic' => new GenericSemverDialect(),
             'composer' => new ComposerDialect(),
@@ -26,13 +26,13 @@ describe('All Dialects Implementation', function () {
         ];
 
         expect($dialects)->toHaveCount(8);
-        
-        foreach ($dialects as $name => $dialect) {
+
+        foreach ($dialects as $dialect) {
             expect($dialect)->toBeInstanceOf(Grazulex\SemverSieve\Contracts\DialectInterface::class);
         }
     });
 
-    it('can create Sieve with all dialects', function () {
+    it('can create Sieve with all dialects', function (): void {
         $dialects = [
             new GenericSemverDialect(),
             new ComposerDialect(),
@@ -50,7 +50,7 @@ describe('All Dialects Implementation', function () {
         }
     });
 
-    it('can parse basic versions with each dialect', function () {
+    it('can parse basic versions with each dialect', function (): void {
         $tests = [
             [new GenericSemverDialect(), '1.2.3'],
             [new ComposerDialect(), '1.2.3'],
@@ -68,7 +68,7 @@ describe('All Dialects Implementation', function () {
         }
     });
 
-    it('can parse basic ranges with each dialect', function () {
+    it('can parse basic ranges with each dialect', function (): void {
         $tests = [
             [new GenericSemverDialect(), '1.2.3'],
             [new ComposerDialect(), '1.2.3'],

--- a/tests/Unit/ParsedVersionTest.php
+++ b/tests/Unit/ParsedVersionTest.php
@@ -43,7 +43,7 @@ describe('ParsedVersion', function (): void {
     });
 
     it('should reject negative version numbers', function (): void {
-        expect(fn () => new ParsedVersion(-1, 0, 0))
+        expect(fn (): \Grazulex\SemverSieve\ValueObjects\ParsedVersion => new ParsedVersion(-1, 0, 0))
             ->toThrow(InvalidArgumentException::class, 'Version numbers cannot be negative');
     });
 


### PR DESCRIPTION
…licts

- Update PHP requirement from ^8.1 to ^8.2 for readonly class support
- Modernize GitHub Actions workflows to use latest action versions
- Resolve style conflicts between PHP CS Fixer and Rector
- Apply Rector optimizations for modern PHP 8.2+ features
- Fix PHPStan annotations for proper type consistency
- All quality tools now pass: PHP CS Fixer (0 issues), PHPStan (no errors), Rector (clean)
- Tests continue to pass (42 passed, 126 assertions)

Breaking Change: Minimum PHP version is now 8.2